### PR TITLE
Fix plugin.pcss include.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm-run-all -p build:*",
-    "build:css": "cat src/plugin.css src/styles.css | postcss -o dist/videojs-super-resolution.css --config scripts/postcss.config.js ",
+    "build:css": "cat src/plugin.pcss src/styles.css | postcss -o dist/videojs-super-resolution.css --config scripts/postcss.config.js ",
     "build:js": "rollup -c scripts/rollup.config.js",
     "clean": "shx rm -rf ./dist ./test/dist",
     "postclean": "shx mkdir -p ./dist ./test/dist",


### PR DESCRIPTION
The upscaled video was below the original video instead of overlayed on top. This was caused when I renamed the postcss file from .css to .pcss but didn't rename it in the build script. My css didn't update so it still worked until I reset it today.